### PR TITLE
Unify customer and employee workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+ClarityExpress/.build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 ClarityExpress/.build/
+ClarityExpress/.swiftpm/

--- a/ClarityExpress/AccountView.swift
+++ b/ClarityExpress/AccountView.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+struct AccountView: View {
+    @EnvironmentObject var appState: AppState
+    @State private var showingVehicleForm = false
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("User Information")) {
+                    TextField("First Name", text: $appState.user.firstName)
+                    TextField("Last Name", text: $appState.user.lastName)
+                    TextField("Phone", text: $appState.user.phone)
+                    TextField("Email", text: $appState.user.email)
+                    TextField("Address", text: $appState.user.address)
+                }
+
+                Section(header: Text("Plan")) {
+                    if let plan = appState.selectedPlan {
+                        Text("\(plan.name) - $\(plan.price)/mo")
+                        Button("Change Plan") { showingVehicleForm = false }
+                            .buttonStyle(PillButtonStyle())
+                    } else {
+                        Button("Select Plan") { showingVehicleForm = false }
+                            .buttonStyle(PillButtonStyle())
+                    }
+                }
+
+                Section(header: Text("Vehicles")) {
+                    ForEach(appState.user.vehicles.indices, id: \.self) { index in
+                        Text(appState.user.vehicles[index].description)
+                            .padding(8)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(appState.selectedVehicleIndex == index ? Theme.selection.opacity(0.3) : Color.clear)
+                            .cornerRadius(8)
+                            .onTapGesture {
+                                withAnimation { appState.selectedVehicleIndex = index }
+                            }
+                    }
+                    Button("Add Vehicle") { showingVehicleForm = true }
+                        .buttonStyle(PillButtonStyle())
+                }
+            }
+            .listStyle(.insetGrouped)
+            .scrollContentBackground(.hidden)
+            .background(Theme.background)
+            .navigationTitle("Account")
+            .tint(Theme.accent)
+            .sheet(isPresented: $showingVehicleForm) {
+                VehicleFormView()
+                    .environmentObject(appState)
+            }
+        }
+    }
+}

--- a/ClarityExpress/ClarityExpressApp.swift
+++ b/ClarityExpress/ClarityExpressApp.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+import UIKit
+
+@main
+struct ClarityExpressApp: App {
+    @StateObject private var appState = AppState()
+
+    var body: some Scene {
+        WindowGroup {
+            if appState.user.role == .employee {
+                EmployeeJobView()
+                    .environmentObject(appState)
+            } else {
+                ContentView()
+                    .environmentObject(appState)
+            }
+        }
+    }
+}
+
+final class AppState: ObservableObject {
+    @Published var user: User = User()
+    @Published var selectedVehicleIndex: Int = 0
+    @Published var selectedPlan: Plan? = nil
+    @Published var washesUsed: Int = 0
+
+    var washesRemaining: Int {
+        guard let plan = selectedPlan else { return 0 }
+        return max(plan.washesPerCycle - washesUsed, 0)
+    }
+
+    func purchase(plan: Plan) {
+        // Placeholder for Square or Stripe payment integration
+        selectedPlan = plan
+        washesUsed = 0
+    }
+
+    func requestWash() {
+        guard let plan = selectedPlan,
+              user.vehicles.indices.contains(selectedVehicleIndex) else { return }
+        let vehicle = user.vehicles[selectedVehicleIndex]
+        let subject = "Wash Request"
+        let body = "User: \(user.firstName) \(user.lastName)\nPlan: \(plan.name)\nVehicle: \(vehicle.description)"
+        let encodedBody = body.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        let urlString = "mailto:support@claritycarwashing.com?subject=\(subject)&body=\(encodedBody)"
+        if let url = URL(string: urlString) {
+            UIApplication.shared.open(url)
+        }
+        washesUsed += 1
+    }
+}

--- a/ClarityExpress/ClarityExpressApp.swift
+++ b/ClarityExpress/ClarityExpressApp.swift
@@ -1,5 +1,7 @@
 import SwiftUI
+#if canImport(UIKit)
 import UIKit
+#endif
 
 @main
 struct ClarityExpressApp: App {
@@ -30,6 +32,7 @@ final class AppState: ObservableObject {
     }
 
     func purchase(plan: Plan) {
+        #if canImport(UIKit)
         guard let root = UIApplication.shared.connectedScenes
             .compactMap({ ($0 as? UIWindowScene)?.keyWindow })
             .first?.rootViewController else {
@@ -45,6 +48,9 @@ final class AppState: ObservableObject {
                 print("Payment canceled or failed")
             }
         }
+        #else
+        print("Stripe checkout unavailable on this platform")
+        #endif
     }
 
     func requestWash() {
@@ -55,9 +61,13 @@ final class AppState: ObservableObject {
         let body = "User: \(user.firstName) \(user.lastName)\nPlan: \(plan.name)\nVehicle: \(vehicle.description)"
         let encodedBody = body.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
         let urlString = "mailto:support@claritycarwashing.com?subject=\(subject)&body=\(encodedBody)"
+        #if canImport(UIKit)
         if let url = URL(string: urlString) {
             UIApplication.shared.open(url)
         }
+        #else
+        print("Would send email: \(urlString)")
+        #endif
         washesUsed += 1
     }
 }

--- a/ClarityExpress/ClarityExpressApp.swift
+++ b/ClarityExpress/ClarityExpressApp.swift
@@ -30,9 +30,21 @@ final class AppState: ObservableObject {
     }
 
     func purchase(plan: Plan) {
-        // Placeholder for Square or Stripe payment integration
-        selectedPlan = plan
-        washesUsed = 0
+        guard let root = UIApplication.shared.connectedScenes
+            .compactMap({ ($0 as? UIWindowScene)?.keyWindow })
+            .first?.rootViewController else {
+                return
+        }
+        StripeManager.shared.startCheckout(from: root) { success in
+            if success {
+                DispatchQueue.main.async {
+                    self.selectedPlan = plan
+                    self.washesUsed = 0
+                }
+            } else {
+                print("Payment canceled or failed")
+            }
+        }
     }
 
     func requestWash() {

--- a/ClarityExpress/ContentView.swift
+++ b/ClarityExpress/ContentView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct ContentView: View {
+    @State private var selection = 0
+
+    var body: some View {
+        TabView(selection: $selection) {
+            HomeView()
+                .tabItem { Label("Home", systemImage: "house") }
+                .tag(0)
+            AccountView()
+                .tabItem { Label("Account", systemImage: "person.crop.circle") }
+                .tag(1)
+            SupportView()
+                .tabItem { Label("Support", systemImage: "phone") }
+                .tag(2)
+        }
+        .background(Theme.background)
+        .tint(Theme.accent)
+        .animation(.easeInOut, value: selection)
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+            .environmentObject(AppState())
+    }
+}

--- a/ClarityExpress/EmployeeJobView.swift
+++ b/ClarityExpress/EmployeeJobView.swift
@@ -50,8 +50,16 @@ struct EmployeeJobView: View {
             .navigationTitle("Job")
             .tint(Theme.accent)
         }
-        .onChange(of: beforeItems) { _ in uploadPhotos(items: beforeItems, storing: &job.beforePhotoURLs, folder: "before") }
-        .onChange(of: afterItems) { _ in uploadPhotos(items: afterItems, storing: &job.afterPhotoURLs, folder: "after") }
+        .onChange(of: beforeItems) { _ in
+            Task {
+                job.beforePhotoURLs = await uploadPhotos(items: beforeItems, folder: "before")
+            }
+        }
+        .onChange(of: afterItems) { _ in
+            Task {
+                job.afterPhotoURLs = await uploadPhotos(items: afterItems, folder: "after")
+            }
+        }
     }
 
     func updateStatus(_ newStatus: JobStatus) {
@@ -76,23 +84,22 @@ struct EmployeeJobView: View {
         }
     }
 
-    func uploadPhotos(items: [PhotosPickerItem], storing array: inout [URL], folder: String) {
-        array.removeAll()
+    func uploadPhotos(items: [PhotosPickerItem], folder: String) async -> [URL] {
+        var uploaded: [URL] = []
         for item in items {
-            Task {
-                if let data = try? await item.loadTransferable(type: Data.self) {
-                    let path = "jobs/\(job.id.uuidString)/\(folder)/\(UUID().uuidString).jpg"
-                    let ref = Storage.storage().reference().child(path)
-                    do {
-                        _ = try await ref.putDataAsync(data)
-                        let url = try await ref.downloadURL()
-                        array.append(url)
-                    } catch {
-                        print("Upload failed: \(error)")
-                    }
+            if let data = try? await item.loadTransferable(type: Data.self) {
+                let path = "jobs/\(job.id.uuidString)/\(folder)/\(UUID().uuidString).jpg"
+                let ref = Storage.storage().reference().child(path)
+                do {
+                    _ = try await ref.putDataAsync(data)
+                    let url = try await ref.downloadURL()
+                    uploaded.append(url)
+                } catch {
+                    print("Upload failed: \(error)")
                 }
             }
         }
+        return uploaded
     }
 
     func callDispatch() {

--- a/ClarityExpress/EmployeeJobView.swift
+++ b/ClarityExpress/EmployeeJobView.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+import PhotosUI
+import MapKit
+
+struct EmployeeJobView: View {
+    @State private var job = Job(vehicle: Vehicle(year: "", make: "", model: "", color: ""))
+    @State private var beforeItems: [PhotosPickerItem] = []
+    @State private var afterItems: [PhotosPickerItem] = []
+    @State private var eta: TimeInterval? = nil
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("Status")) {
+                    Text("Current: \(job.status.rawValue.capitalized)")
+                    if job.status == .pending {
+                        Button("On The Way") { updateStatus(.onTheWay) }
+                            .buttonStyle(PillButtonStyle())
+                    } else if job.status == .onTheWay {
+                        Button("Arrived") { updateStatus(.arrived) }
+                            .buttonStyle(PillButtonStyle())
+                    } else if job.status == .arrived {
+                        Button("Service Completed") { updateStatus(.completed) }
+                            .buttonStyle(PillButtonStyle())
+                    }
+                    if let eta = eta, job.status == .onTheWay {
+                        Text("ETA: \(format(eta))")
+                    }
+                }
+
+                Section(header: Text("Before Photos")) {
+                    PhotosPicker("Select Photos", selection: $beforeItems, maxSelectionCount: 4, matching: .images)
+                    Text("\(beforeItems.count)/4 selected")
+                }
+
+                Section(header: Text("After Photos")) {
+                    PhotosPicker("Select Photos", selection: $afterItems, maxSelectionCount: 4, matching: .images)
+                    Text("\(afterItems.count)/4 selected")
+                }
+
+                Section {
+                    Button("Call Dispatch") { callDispatch() }
+                        .buttonStyle(PillButtonStyle())
+                }
+            }
+            .listStyle(.insetGrouped)
+            .scrollContentBackground(.hidden)
+            .background(Theme.background)
+            .navigationTitle("Job")
+            .tint(Theme.accent)
+        }
+        .onChange(of: beforeItems) { _ in loadPhotos(items: beforeItems, storing: &job.beforePhotos) }
+        .onChange(of: afterItems) { _ in loadPhotos(items: afterItems, storing: &job.afterPhotos) }
+    }
+
+    func updateStatus(_ newStatus: JobStatus) {
+        job.status = newStatus
+        if newStatus == .onTheWay {
+            fetchETA()
+        }
+        notifyUser(status: newStatus, eta: eta)
+    }
+
+    func notifyUser(status: JobStatus, eta: TimeInterval?) {
+        // TODO: integrate messaging to inform the user of status and optional ETA
+    }
+
+    func fetchETA() {
+        let request = MKDirections.Request()
+        request.source = .forCurrentLocation()
+        // Destination should be set based on job address
+        // request.destination = ...
+        MKDirections(request: request).calculateETA { response, _ in
+            eta = response?.expectedTravelTime
+        }
+    }
+
+    func loadPhotos(items: [PhotosPickerItem], storing array: inout [Data]) {
+        array.removeAll()
+        for item in items {
+            Task {
+                if let data = try? await item.loadTransferable(type: Data.self) {
+                    array.append(data)
+                }
+            }
+        }
+    }
+
+    func callDispatch() {
+        if let url = URL(string: "tel://6195107939") {
+            UIApplication.shared.open(url)
+        }
+    }
+
+    func format(_ interval: TimeInterval) -> String {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.minute]
+        formatter.unitsStyle = .short
+        return formatter.string(from: interval) ?? ""
+    }
+}
+
+struct EmployeeJobView_Previews: PreviewProvider {
+    static var previews: some View {
+        EmployeeJobView()
+    }
+}

--- a/ClarityExpress/EmployeeJobView.swift
+++ b/ClarityExpress/EmployeeJobView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import PhotosUI
 import MapKit
+import FirebaseStorage
 
 struct EmployeeJobView: View {
     @State private var job = Job(vehicle: Vehicle(year: "", make: "", model: "", color: ""))
@@ -30,12 +31,12 @@ struct EmployeeJobView: View {
 
                 Section(header: Text("Before Photos")) {
                     PhotosPicker("Select Photos", selection: $beforeItems, maxSelectionCount: 4, matching: .images)
-                    Text("\(beforeItems.count)/4 selected")
+                    Text("\(job.beforePhotoURLs.count)/4 uploaded")
                 }
 
                 Section(header: Text("After Photos")) {
                     PhotosPicker("Select Photos", selection: $afterItems, maxSelectionCount: 4, matching: .images)
-                    Text("\(afterItems.count)/4 selected")
+                    Text("\(job.afterPhotoURLs.count)/4 uploaded")
                 }
 
                 Section {
@@ -49,8 +50,8 @@ struct EmployeeJobView: View {
             .navigationTitle("Job")
             .tint(Theme.accent)
         }
-        .onChange(of: beforeItems) { _ in loadPhotos(items: beforeItems, storing: &job.beforePhotos) }
-        .onChange(of: afterItems) { _ in loadPhotos(items: afterItems, storing: &job.afterPhotos) }
+        .onChange(of: beforeItems) { _ in uploadPhotos(items: beforeItems, storing: &job.beforePhotoURLs, folder: "before") }
+        .onChange(of: afterItems) { _ in uploadPhotos(items: afterItems, storing: &job.afterPhotoURLs, folder: "after") }
     }
 
     func updateStatus(_ newStatus: JobStatus) {
@@ -75,12 +76,20 @@ struct EmployeeJobView: View {
         }
     }
 
-    func loadPhotos(items: [PhotosPickerItem], storing array: inout [Data]) {
+    func uploadPhotos(items: [PhotosPickerItem], storing array: inout [URL], folder: String) {
         array.removeAll()
         for item in items {
             Task {
                 if let data = try? await item.loadTransferable(type: Data.self) {
-                    array.append(data)
+                    let path = "jobs/\(job.id.uuidString)/\(folder)/\(UUID().uuidString).jpg"
+                    let ref = Storage.storage().reference().child(path)
+                    do {
+                        _ = try await ref.putDataAsync(data)
+                        let url = try await ref.downloadURL()
+                        array.append(url)
+                    } catch {
+                        print("Upload failed: \(error)")
+                    }
                 }
             }
         }

--- a/ClarityExpress/HomeView.swift
+++ b/ClarityExpress/HomeView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+struct HomeView: View {
+    @EnvironmentObject var appState: AppState
+    @State private var showingPlanSheet = false
+    @State private var showingVehicleSheet = false
+    @State private var washRequested = false
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 24) {
+                if let plan = appState.selectedPlan {
+                    Text("Current Plan: \(plan.name)")
+                    HStack {
+                        Text("Washes Remaining: ")
+                        RollingNumberView(value: appState.washesRemaining)
+                        Text("/\(plan.washesPerCycle)")
+                    }
+                } else {
+                    Button("Select Plan") { showingPlanSheet = true }
+                        .buttonStyle(PillButtonStyle())
+                }
+
+                if appState.user.vehicles.indices.contains(appState.selectedVehicleIndex) {
+                    let vehicle = appState.user.vehicles[appState.selectedVehicleIndex]
+                    Text("Vehicle: \(vehicle.description)")
+                } else {
+                    Button("Add Vehicle") { showingVehicleSheet = true }
+                        .buttonStyle(PillButtonStyle())
+                }
+
+                Button("Request Wash") {
+                    withAnimation {
+                        appState.requestWash()
+                        washRequested = true
+                    }
+                }
+                .disabled(appState.selectedPlan == nil || appState.user.vehicles.isEmpty || appState.washesRemaining == 0)
+                .buttonStyle(PillButtonStyle())
+                .alert("Wash Requested!", isPresented: $washRequested) {
+                    Button("OK", role: .cancel) { }
+                }
+
+                Spacer()
+            }
+            .padding()
+            .background(Theme.background)
+            .navigationTitle("Clarity Express")
+            .tint(Theme.accent)
+            .sheet(isPresented: $showingPlanSheet) {
+                PlanSelectionView()
+                    .environmentObject(appState)
+            }
+            .sheet(isPresented: $showingVehicleSheet) {
+                VehicleFormView()
+                    .environmentObject(appState)
+            }
+        }
+    }
+}

--- a/ClarityExpress/Models.swift
+++ b/ClarityExpress/Models.swift
@@ -46,6 +46,8 @@ struct Job: Identifiable, Codable {
     let id = UUID()
     var vehicle: Vehicle
     var status: JobStatus = .pending
-    var beforePhotos: [Data] = []
-    var afterPhotos: [Data] = []
+    /// Download URLs for before-service photos stored in Firebase Storage
+    var beforePhotoURLs: [URL] = []
+    /// Download URLs for after-service photos stored in Firebase Storage
+    var afterPhotoURLs: [URL] = []
 }

--- a/ClarityExpress/Models.swift
+++ b/ClarityExpress/Models.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+struct Plan: Identifiable, Codable, Equatable {
+    let id = UUID()
+    let name: String
+    let price: Int
+    let description: String
+    let washesPerCycle: Int
+}
+
+struct Vehicle: Identifiable, Codable {
+    let id = UUID()
+    var year: String
+    var make: String
+    var model: String
+    var color: String
+
+    var description: String {
+        "\(year) \(make) \(model) - \(color)"
+    }
+}
+
+struct User: Codable {
+    enum Role: String, Codable {
+        case customer
+        case employee
+    }
+
+    var firstName: String = ""
+    var lastName: String = ""
+    var phone: String = ""
+    var email: String = ""
+    var address: String = ""
+    var vehicles: [Vehicle] = []
+    var role: Role = .customer
+}
+
+enum JobStatus: String, Codable, CaseIterable {
+    case pending
+    case onTheWay
+    case arrived
+    case completed
+}
+
+struct Job: Identifiable, Codable {
+    let id = UUID()
+    var vehicle: Vehicle
+    var status: JobStatus = .pending
+    var beforePhotos: [Data] = []
+    var afterPhotos: [Data] = []
+}

--- a/ClarityExpress/Package.resolved
+++ b/ClarityExpress/Package.resolved
@@ -109,6 +109,15 @@
       }
     },
     {
+      "identity" : "stripe-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stripe/stripe-ios",
+      "state" : {
+        "revision" : "b3cfef0afb1aad0200d6e7ce016abd60303e4e05",
+        "version" : "24.23.0"
+      }
+    },
+    {
       "identity" : "swift-protobuf",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",

--- a/ClarityExpress/Package.resolved
+++ b/ClarityExpress/Package.resolved
@@ -1,0 +1,122 @@
+{
+  "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "194a6706acbd25e4ef639bcaddea16e8758a3e27",
+        "version" : "1.2024011602.0"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "3b62f154d00019ae29a71e9738800bb6f18b236d",
+        "version" : "10.19.2"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk",
+      "state" : {
+        "revision" : "eca84fd638116dd6adb633b5a3f31cc7befcbb7d",
+        "version" : "10.29.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "fe727587518729046fc1465625b9afd80b5ab361",
+        "version" : "10.28.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "a637d318ae7ae246b02d7305121275bc75ed5565",
+        "version" : "9.4.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "57a1d307f42df690fdef2637f3e5b776da02aad6",
+        "version" : "7.13.3"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "e9fad491d0673bdda7063a0341fb6b47a30c5359",
+        "version" : "1.62.2"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "a2ab612cb980066ee56d90d60d8462992c07f24b",
+        "version" : "3.5.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
+        "version" : "100.0.0"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "e3f69fd321d0c9fcdc16fb576a0cdd956675face",
+        "version" : "1.31.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/ClarityExpress/Package.swift
+++ b/ClarityExpress/Package.swift
@@ -9,9 +9,15 @@ let package = Package(
     products: [
         .executable(name: "ClarityExpress", targets: ["ClarityExpress"])
     ],
+    dependencies: [
+        .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "10.15.0")
+    ],
     targets: [
         .executableTarget(
             name: "ClarityExpress",
+            dependencies: [
+                .product(name: "FirebaseStorage", package: "firebase-ios-sdk")
+            ],
             path: "."
         )
     ]

--- a/ClarityExpress/Package.swift
+++ b/ClarityExpress/Package.swift
@@ -10,13 +10,15 @@ let package = Package(
         .executable(name: "ClarityExpress", targets: ["ClarityExpress"])
     ],
     dependencies: [
-        .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "10.15.0")
+        .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "10.15.0"),
+        .package(url: "https://github.com/stripe/stripe-ios", from: "24.8.0")
     ],
     targets: [
         .executableTarget(
             name: "ClarityExpress",
             dependencies: [
-                .product(name: "FirebaseStorage", package: "firebase-ios-sdk")
+                .product(name: "FirebaseStorage", package: "firebase-ios-sdk"),
+                .product(name: "StripePaymentSheet", package: "stripe-ios")
             ],
             path: "."
         )

--- a/ClarityExpress/Package.swift
+++ b/ClarityExpress/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "ClarityExpress",
+    platforms: [
+        .iOS(.v15)
+    ],
+    products: [
+        .executable(name: "ClarityExpress", targets: ["ClarityExpress"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "ClarityExpress",
+            path: "."
+        )
+    ]
+)

--- a/ClarityExpress/Package.swift
+++ b/ClarityExpress/Package.swift
@@ -20,7 +20,8 @@ let package = Package(
                 .product(name: "FirebaseStorage", package: "firebase-ios-sdk"),
                 .product(name: "StripePaymentSheet", package: "stripe-ios")
             ],
-            path: "."
+            path: ".",
+            exclude: ["README.md"]
         )
     ]
 )

--- a/ClarityExpress/Package.swift
+++ b/ClarityExpress/Package.swift
@@ -13,6 +13,9 @@ stripeDependency.append(
 stripeProducts.append(
     .product(name: "StripePaymentSheet", package: "stripe-ios")
 )
+stripeProducts.append(
+    .product(name: "Stripe3DS2", package: "stripe-ios")
+)
 #endif
 
 let package = Package(

--- a/ClarityExpress/Package.swift
+++ b/ClarityExpress/Package.swift
@@ -1,6 +1,20 @@
 // swift-tools-version: 5.9
 import PackageDescription
 
+// Conditionally include Stripe only when UIKit is available so the package can
+// still be resolved on platforms that lack Apple's UI frameworks (e.g. Linux).
+
+var stripeDependency: [Package.Dependency] = []
+var stripeProducts: [Target.Dependency] = []
+#if canImport(UIKit)
+stripeDependency.append(
+    .package(url: "https://github.com/stripe/stripe-ios", from: "24.8.0")
+)
+stripeProducts.append(
+    .product(name: "StripePaymentSheet", package: "stripe-ios")
+)
+#endif
+
 let package = Package(
     name: "ClarityExpress",
     platforms: [
@@ -10,16 +24,14 @@ let package = Package(
         .executable(name: "ClarityExpress", targets: ["ClarityExpress"])
     ],
     dependencies: [
-        .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "10.15.0"),
-        .package(url: "https://github.com/stripe/stripe-ios", from: "24.8.0")
-    ],
+        .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "10.15.0")
+    ] + stripeDependency,
     targets: [
         .executableTarget(
             name: "ClarityExpress",
             dependencies: [
-                .product(name: "FirebaseStorage", package: "firebase-ios-sdk"),
-                .product(name: "StripePaymentSheet", package: "stripe-ios")
-            ],
+                .product(name: "FirebaseStorage", package: "firebase-ios-sdk")
+            ] + stripeProducts,
             path: ".",
             exclude: ["README.md"]
         )

--- a/ClarityExpress/PlanSelectionView.swift
+++ b/ClarityExpress/PlanSelectionView.swift
@@ -1,42 +1,42 @@
 import SwiftUI
 
+struct PlanOption: Identifiable {
+    let id = UUID()
+    let planName: String
+    let washesPerMonth: Int
+    let pricePerWash: Double
+    let monthlyPrice: Double
+}
+
 struct PlanSelectionView: View {
     @Environment(\.dismiss) var dismiss
     @EnvironmentObject var appState: AppState
 
-    let plans: [Plan] = [
-        Plan(name: "Basic", price: 119, description: "Foam wash & rinse, air dry, window scrubbing, light road grime removal", washesPerCycle: 4),
-        Plan(name: "Premium", price: 149, description: "Includes Basic plus microfiber mitt scrub, heavy dirt & grime removal", washesPerCycle: 4),
-        Plan(name: "Elite", price: 199, description: "Includes Premium plus towel dry and ceramic wax", washesPerCycle: 4)
+    private let planDescriptions: [String: String] = [
+        "Basic": "Foam wash & rinse, air dry, window scrubbing, light road grime removal",
+        "Premium": "Includes Basic plus microfiber mitt scrub, heavy dirt & grime removal",
+        "Elite": "Includes Premium plus towel dry and ceramic wax"
+    ]
+
+    private let options: [PlanOption] = [
+        PlanOption(planName: "Basic", washesPerMonth: 1, pricePerWash: 45.0, monthlyPrice: 45.0),
+        PlanOption(planName: "Basic", washesPerMonth: 2, pricePerWash: 40.0, monthlyPrice: 80.0),
+        PlanOption(planName: "Basic", washesPerMonth: 4, pricePerWash: 29.75, monthlyPrice: 119.0),
+        PlanOption(planName: "Premium", washesPerMonth: 1, pricePerWash: 50.0, monthlyPrice: 50.0),
+        PlanOption(planName: "Premium", washesPerMonth: 2, pricePerWash: 45.0, monthlyPrice: 90.0),
+        PlanOption(planName: "Premium", washesPerMonth: 4, pricePerWash: 37.25, monthlyPrice: 149.0),
+        PlanOption(planName: "Elite", washesPerMonth: 1, pricePerWash: 60.0, monthlyPrice: 60.0),
+        PlanOption(planName: "Elite", washesPerMonth: 2, pricePerWash: 55.0, monthlyPrice: 110.0),
+        PlanOption(planName: "Elite", washesPerMonth: 4, pricePerWash: 49.75, monthlyPrice: 199.0)
     ]
 
     var body: some View {
         NavigationView {
             ScrollView {
                 VStack(spacing: 16) {
-                    ForEach(plans) { plan in
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text(plan.name)
-                                .font(.headline)
-                            Text("$\(plan.price)/mo")
-                            Text(plan.description)
-                                .font(.subheadline)
-                        }
-                        .padding()
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(Theme.background)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 12)
-                                .stroke(appState.selectedPlan?.name == plan.name ? Theme.selection : Color.clear, lineWidth: 2)
-                        )
-                        .cornerRadius(12)
-                        .shadow(color: Theme.selection.opacity(0.3), radius: 2, x: 0, y: 1)
-                        .onTapGesture {
-                            withAnimation {
-                                appState.purchase(plan: plan)
-                                dismiss()
-                            }
-                        }
+                    headerRow
+                    ForEach(options) { option in
+                        row(for: option)
                     }
                 }
                 .padding()
@@ -44,6 +44,51 @@ struct PlanSelectionView: View {
             .background(Theme.background)
             .navigationTitle("Select Plan")
             .tint(Theme.accent)
+        }
+    }
+
+    private var headerRow: some View {
+        HStack {
+            Text("Plan")
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Text("Washes/Month")
+                .frame(maxWidth: .infinity)
+            Text("Price/Wash")
+                .frame(maxWidth: .infinity)
+            Text("Monthly")
+                .frame(maxWidth: .infinity, alignment: .trailing)
+        }
+        .font(.caption)
+        .foregroundColor(.secondary)
+    }
+
+    @ViewBuilder
+    private func row(for option: PlanOption) -> some View {
+        let isSelected = appState.selectedPlan?.name == option.planName && appState.selectedPlan?.washesPerCycle == option.washesPerMonth
+        HStack {
+            Text(option.planName)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Text("\(option.washesPerMonth)")
+                .frame(maxWidth: .infinity)
+            Text(String(format: "$%.2f", option.pricePerWash))
+                .frame(maxWidth: .infinity)
+            Text(String(format: "$%.2f", option.monthlyPrice))
+                .frame(maxWidth: .infinity, alignment: .trailing)
+        }
+        .padding(8)
+        .background(Theme.background)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(isSelected ? Theme.selection : Color.clear, lineWidth: 2)
+        )
+        .cornerRadius(8)
+        .onTapGesture {
+            let description = planDescriptions[option.planName] ?? ""
+            let plan = Plan(name: option.planName, price: Int(option.monthlyPrice), description: description, washesPerCycle: option.washesPerMonth)
+            withAnimation {
+                appState.purchase(plan: plan)
+                dismiss()
+            }
         }
     }
 }

--- a/ClarityExpress/PlanSelectionView.swift
+++ b/ClarityExpress/PlanSelectionView.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+struct PlanSelectionView: View {
+    @Environment(\.dismiss) var dismiss
+    @EnvironmentObject var appState: AppState
+
+    let plans: [Plan] = [
+        Plan(name: "Basic", price: 119, description: "Foam wash & rinse, air dry, window scrubbing, light road grime removal", washesPerCycle: 4),
+        Plan(name: "Premium", price: 149, description: "Includes Basic plus microfiber mitt scrub, heavy dirt & grime removal", washesPerCycle: 4),
+        Plan(name: "Elite", price: 199, description: "Includes Premium plus towel dry and ceramic wax", washesPerCycle: 4)
+    ]
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(spacing: 16) {
+                    ForEach(plans) { plan in
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text(plan.name)
+                                .font(.headline)
+                            Text("$\(plan.price)/mo")
+                            Text(plan.description)
+                                .font(.subheadline)
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Theme.background)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(appState.selectedPlan?.name == plan.name ? Theme.selection : Color.clear, lineWidth: 2)
+                        )
+                        .cornerRadius(12)
+                        .shadow(color: Theme.selection.opacity(0.3), radius: 2, x: 0, y: 1)
+                        .onTapGesture {
+                            withAnimation {
+                                appState.purchase(plan: plan)
+                                dismiss()
+                            }
+                        }
+                    }
+                }
+                .padding()
+            }
+            .background(Theme.background)
+            .navigationTitle("Select Plan")
+            .tint(Theme.accent)
+        }
+    }
+}

--- a/ClarityExpress/README.md
+++ b/ClarityExpress/README.md
@@ -14,7 +14,7 @@ Clarity Express is an on-demand mobile car wash app for iOS.
 - Account management for profile, plan and multiple vehicles.
 - Support tab with direct phone link to customer service (619-733-6995).
 - Plan purchasing is structured for Square (or Stripe) payment integration.
-- Employees sign in to the same app to access a job workflow that updates customers when the detailer is on the way, has arrived, or finished, captures up to four before/after photos, and provides a dispatch call shortcut at 619-510-7939.
+- Employees sign in to the same app to access a job workflow that updates customers when the detailer is on the way, has arrived, or finished, uploads up to four before/after photos to Firebase Storage, and provides a dispatch call shortcut at 619-510-7939.
 - Modern interface with traffic blue accents (#0E518D), silver selection highlights, pill-shaped buttons and animated transitions. The remaining-washes counter rolls down like a slot machine when a wash is requested.
 
 This repository provides a SwiftUI prototype of the interface.

--- a/ClarityExpress/README.md
+++ b/ClarityExpress/README.md
@@ -13,7 +13,7 @@ Clarity Express is an on-demand mobile car wash app for iOS.
 - Wash requests email details (user, plan, vehicle) to support@claritycarwashing.com.
 - Account management for profile, plan and multiple vehicles.
 - Support tab with direct phone link to customer service (619-733-6995).
-- Plan purchasing is structured for Square (or Stripe) payment integration.
+- Plan purchasing now launches a Stripe PaymentSheet checkout using a backend endpoint to create customers, ephemeral keys and payment intents.
 - Employees sign in to the same app to access a job workflow that updates customers when the detailer is on the way, has arrived, or finished, uploads up to four before/after photos to Firebase Storage, and provides a dispatch call shortcut at 619-510-7939.
 - Modern interface with traffic blue accents (#0E518D), silver selection highlights, pill-shaped buttons and animated transitions. The remaining-washes counter rolls down like a slot machine when a wash is requested.
 

--- a/ClarityExpress/README.md
+++ b/ClarityExpress/README.md
@@ -1,0 +1,20 @@
+# Clarity Express
+
+Clarity Express is an on-demand mobile car wash app for iOS.
+
+## Features
+- Users sign up with personal and vehicle information.
+- Three shareable monthly plans:
+  - **Basic** – $119/mo, 4 washes, foam wash & rinse, air dry, window scrubbing, light road grime removal.
+  - **Premium** – $149/mo, includes Basic plus microfiber mitt scrub and heavy dirt & grime removal.
+  - **Elite** – $199/mo, includes Premium plus towel dry and ceramic wax.
+- Request a wash within a two-hour window and choose the vehicle.
+- Home view shows remaining washes for the current billing cycle.
+- Wash requests email details (user, plan, vehicle) to support@claritycarwashing.com.
+- Account management for profile, plan and multiple vehicles.
+- Support tab with direct phone link to customer service (619-733-6995).
+- Plan purchasing is structured for Square (or Stripe) payment integration.
+- Employees sign in to the same app to access a job workflow that updates customers when the detailer is on the way, has arrived, or finished, captures up to four before/after photos, and provides a dispatch call shortcut at 619-510-7939.
+- Modern interface with traffic blue accents (#0E518D), silver selection highlights, pill-shaped buttons and animated transitions. The remaining-washes counter rolls down like a slot machine when a wash is requested.
+
+This repository provides a SwiftUI prototype of the interface.

--- a/ClarityExpress/README.md
+++ b/ClarityExpress/README.md
@@ -5,9 +5,19 @@ Clarity Express is an on-demand mobile car wash app for iOS.
 ## Features
 - Users sign up with personal and vehicle information.
 - Three shareable monthly plans:
-  - **Basic** – $119/mo, 4 washes, foam wash & rinse, air dry, window scrubbing, light road grime removal.
-  - **Premium** – $149/mo, includes Basic plus microfiber mitt scrub and heavy dirt & grime removal.
-  - **Elite** – $199/mo, includes Premium plus towel dry and ceramic wax.
+
+| Plan | Washes per Month | Price per Wash | Monthly Price |
+| --- | --- | --- | --- |
+| **Basic** | 1 | \$45.00 | \$45.00 |
+|  | 2 | \$40.00 | \$80.00 |
+|  | 4 | \$29.75 | \$119.00 |
+| **Premium** | 1 | \$50.00 | \$50.00 |
+|  | 2 | \$45.00 | \$90.00 |
+|  | 4 | \$37.25 | \$149.00 |
+| **Elite** | 1 | \$60.00 | \$60.00 |
+|  | 2 | \$55.00 | \$110.00 |
+|  | 4 | \$49.75 | \$199.00 |
+
 - Request a wash within a two-hour window and choose the vehicle.
 - Home view shows remaining washes for the current billing cycle.
 - Wash requests email details (user, plan, vehicle) to support@claritycarwashing.com.

--- a/ClarityExpress/RollingNumberView.swift
+++ b/ClarityExpress/RollingNumberView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct RollingNumberView: View {
+    var value: Int
+    private let height: CGFloat = 30
+    @State private var previous: Int
+    @State private var offset: CGFloat = 0
+
+    init(value: Int) {
+        self.value = value
+        _previous = State(initialValue: value)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Text("\(previous)")
+                .frame(height: height)
+            Text("\(value)")
+                .frame(height: height)
+        }
+        .font(.title2.monospacedDigit())
+        .offset(y: offset)
+        .clipped()
+        .onChange(of: value) { newValue in
+            withAnimation(.easeInOut(duration: 0.4)) {
+                offset = -height
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                previous = newValue
+                offset = 0
+            }
+        }
+    }
+}

--- a/ClarityExpress/StripeManager.swift
+++ b/ClarityExpress/StripeManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+#if canImport(UIKit)
 import StripePaymentSheet
 import UIKit
 
@@ -50,3 +51,12 @@ final class StripeManager {
         task.resume()
     }
 }
+#else
+final class StripeManager {
+    static let shared = StripeManager()
+    private init() {}
+    func startCheckout(from controller: Any?, completion: @escaping (Bool) -> Void) {
+        completion(false)
+    }
+}
+#endif

--- a/ClarityExpress/StripeManager.swift
+++ b/ClarityExpress/StripeManager.swift
@@ -1,0 +1,52 @@
+import Foundation
+import StripePaymentSheet
+import UIKit
+
+final class StripeManager {
+    static let shared = StripeManager()
+    private init() {}
+
+    private let backendURL = URL(string: "Your backend endpoint/payment-sheet")!
+    private var paymentSheet: PaymentSheet?
+
+    func startCheckout(from controller: UIViewController, completion: @escaping (Bool) -> Void) {
+        var request = URLRequest(url: backendURL)
+        request.httpMethod = "POST"
+        let task = URLSession.shared.dataTask(with: request) { [weak self] data, _, error in
+            if let error = error {
+                print("Error fetching payment sheet: \(error)")
+                completion(false)
+                return
+            }
+            guard let data = data,
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let customer = json["customer"] as? String,
+                  let ephemeralKey = json["ephemeralKey"] as? String,
+                  let paymentIntent = json["paymentIntent"] as? String,
+                  let publishableKey = json["publishableKey"] as? String else {
+                completion(false)
+                return
+            }
+
+            STPAPIClient.shared.publishableKey = publishableKey
+            var configuration = PaymentSheet.Configuration()
+            configuration.merchantDisplayName = "Clarity Express"
+            configuration.customer = .init(id: customer, ephemeralKeySecret: ephemeralKey)
+            configuration.allowsDelayedPaymentMethods = true
+            configuration.returnURL = "clarityexpress://stripe-redirect"
+            self?.paymentSheet = PaymentSheet(paymentIntentClientSecret: paymentIntent, configuration: configuration)
+
+            DispatchQueue.main.async {
+                self?.paymentSheet?.present(from: controller) { result in
+                    switch result {
+                    case .completed:
+                        completion(true)
+                    default:
+                        completion(false)
+                    }
+                }
+            }
+        }
+        task.resume()
+    }
+}

--- a/ClarityExpress/SupportView.swift
+++ b/ClarityExpress/SupportView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct SupportView: View {
+    let phoneNumber = "6197336995"
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Need Help?")
+                .font(.title)
+            Button(action: callSupport) {
+                Label("Call Support", systemImage: "phone.fill")
+            }
+            .buttonStyle(PillButtonStyle())
+            Spacer()
+        }
+        .padding()
+        .background(Theme.background)
+        .navigationTitle("Support")
+        .tint(Theme.accent)
+    }
+
+    private func callSupport() {
+        if let url = URL(string: "tel://\(phoneNumber)"), UIApplication.shared.canOpenURL(url) {
+            UIApplication.shared.open(url)
+        }
+    }
+}
+
+struct SupportView_Previews: PreviewProvider {
+    static var previews: some View {
+        SupportView()
+    }
+}

--- a/ClarityExpress/Theme.swift
+++ b/ClarityExpress/Theme.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct Theme {
+    static let accent = Color(hex: 0x0E518D)
+    static let selection = Color(hex: 0xC0C0C0)
+    static let background = Color.white
+}
+
+extension Color {
+    init(hex: UInt, alpha: Double = 1) {
+        let r = Double((hex >> 16) & 0xFF) / 255
+        let g = Double((hex >> 8) & 0xFF) / 255
+        let b = Double(hex & 0xFF) / 255
+        self.init(.sRGB, red: r, green: g, blue: b, opacity: alpha)
+    }
+}
+
+struct PillButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .padding(.horizontal, 24)
+            .padding(.vertical, 12)
+            .background(Theme.accent)
+            .foregroundColor(.white)
+            .clipShape(Capsule())
+            .scaleEffect(configuration.isPressed ? 0.95 : 1.0)
+            .animation(.easeOut(duration: 0.2), value: configuration.isPressed)
+            .hoverEffect(.highlight)
+    }
+}

--- a/ClarityExpress/VehicleFormView.swift
+++ b/ClarityExpress/VehicleFormView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct VehicleFormView: View {
+    @Environment(\.dismiss) var dismiss
+    @EnvironmentObject var appState: AppState
+
+    @State private var year = ""
+    @State private var make = ""
+    @State private var model = ""
+    @State private var color = ""
+
+    var body: some View {
+        NavigationView {
+            Form {
+                TextField("Year", text: $year)
+                TextField("Make", text: $make)
+                TextField("Model", text: $model)
+                TextField("Color", text: $color)
+            }
+            .listStyle(.insetGrouped)
+            .scrollContentBackground(.hidden)
+            .background(Theme.background)
+            .navigationTitle("Add Vehicle")
+            .tint(Theme.accent)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        let vehicle = Vehicle(year: year, make: make, model: model, color: color)
+                        appState.user.vehicles.append(vehicle)
+                        dismiss()
+                    }
+                    .buttonStyle(PillButtonStyle())
+                }
+            }
+        }
+    }
+}

--- a/ClarityExpress/VehicleFormView.swift
+++ b/ClarityExpress/VehicleFormView.swift
@@ -11,6 +11,25 @@ struct VehicleFormView: View {
 
     var body: some View {
         NavigationView {
+            form
+                .navigationTitle("Add Vehicle")
+                .tint(Theme.accent)
+                .toolbar {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Save") {
+                            let vehicle = Vehicle(year: year, make: make, model: model, color: color)
+                            appState.user.vehicles.append(vehicle)
+                            dismiss()
+                        }
+                        .buttonStyle(PillButtonStyle())
+                    }
+                }
+        }
+    }
+
+    @ViewBuilder
+    private var form: some View {
+        if #available(iOS 16.0, *) {
             Form {
                 TextField("Year", text: $year)
                 TextField("Make", text: $make)
@@ -20,18 +39,15 @@ struct VehicleFormView: View {
             .listStyle(.insetGrouped)
             .scrollContentBackground(.hidden)
             .background(Theme.background)
-            .navigationTitle("Add Vehicle")
-            .tint(Theme.accent)
-            .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Save") {
-                        let vehicle = Vehicle(year: year, make: make, model: model, color: color)
-                        appState.user.vehicles.append(vehicle)
-                        dismiss()
-                    }
-                    .buttonStyle(PillButtonStyle())
-                }
+        } else {
+            Form {
+                TextField("Year", text: $year)
+                TextField("Make", text: $make)
+                TextField("Model", text: $model)
+                TextField("Color", text: $color)
             }
+            .listStyle(.insetGrouped)
+            .background(Theme.background)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add a role field to `User` so employees and customers share one app
- Drive the root view from the user's role, presenting either the customer tabs or the employee job workflow
- Update documentation to describe the unified experience and dispatch shortcut

## Testing
- ❌ `swift build` (missing SwiftUI module)


------
https://chatgpt.com/codex/tasks/task_e_68b8442178a4832a97d28cabb6e849be